### PR TITLE
Add conversion function to property

### DIFF
--- a/lib/property.hpp
+++ b/lib/property.hpp
@@ -51,6 +51,8 @@ namespace properties
             this->notify();
             return *this;
         }
+
+        operator T() const { return data; }
     };
 
     template<typename T>


### PR DESCRIPTION
Adds a conversion function, so that a property can implicitly be converted to the type it stores.
``` cpp
MAKE_PROPERTY(x, int);

x = 10;
int value = x;
```